### PR TITLE
add sections for python, ruby, data science, django and a few entries…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@
 - [Vue](#vue)
 - [Women in Tech](#women-in-tech)
 
+## APEX
+
+- [Ask TOM](https://asktom.oracle.com/pls/apex/f?p=100:1000::::::)
+- [Oracle APEX Community](https://community.oracle.com/community/technology_network_community/database/developer-tools/application_express)
+- [APEX World](https://apex.world/ords/f?p=APEX_WORLD:HOME)
+- [Oracle LiveSQL](https://livesql.oracle.com/apex/livesql/file/index.html)
+- [APEX Office Hours](https://asktom.oracle.com/pls/apex/f?p=100:551:::NO:551:P551_CLASS_ID:744:)
+- [Maxime Tremblay's Blog](http://max-tremblay.blogspot.com/)
+- [Explorer UK](https://explorer.uk.com/blog/)
+- [Talk APEX](https://www.talkapex.com/)
+- [Joel Kallman's Blog](https://joelkallman.blogspot.com/)
+- [Oracle APEX Website](https://apex.oracle.com/)
+
+
 ## CSS
 
 - [Marksheet.io](https://marksheet.io/)
@@ -144,22 +158,6 @@
 - [MonkeyLearn](https://monkeylearn.com/blog/gentle-guide-to-machine-learning/)
 - [An Introduction to Statistical Learning with Applications in R](http://www-bcf.usc.edu/~gareth/ISL/)
 
-
-## PHP
-
-- [7 days challenge](https://www.guru99.com/php-tutorials.html)
-- [The right way](https://phptherightway.com/)
-- [In site learn](https://www.learn-php.org/)
-- [Complete macos PHP setup](https://getgrav.org/blog/macos-mojave-apache-multiple-php-versions)
-
-
-## Python
-
-- [Learn Python the Hard Way](https://learnpythonthehardway.org/)
-- [CS50's Web Programming with Python and JavaScript](https://www.edx.org/course/cs50s-web-programming-with-python-and-javascript)
-- [Automate the Boring Stuff with Python](http://automatetheboringstuff.com/)
-- [Think Python 2nd Edition](http://greenteapress.com/wp/think-python-2e/)
-
 ## NodeJS
 
 - [Learn Node by Wes Bos](https://learnnode.com/)
@@ -188,19 +186,12 @@
 - [Tutorialspoint](https://www.tutorialspoint.com/nodejs/)
 
 
-## APEX
+## PHP
 
-- [Ask TOM](https://asktom.oracle.com/pls/apex/f?p=100:1000::::::)
-- [Oracle APEX Community](https://community.oracle.com/community/technology_network_community/database/developer-tools/application_express)
-- [APEX World](https://apex.world/ords/f?p=APEX_WORLD:HOME)
-- [Oracle LiveSQL](https://livesql.oracle.com/apex/livesql/file/index.html)
-- [APEX Office Hours](https://asktom.oracle.com/pls/apex/f?p=100:551:::NO:551:P551_CLASS_ID:744:)
-- [Maxime Tremblay's Blog](http://max-tremblay.blogspot.com/)
-- [Explorer UK](https://explorer.uk.com/blog/)
-- [Talk APEX](https://www.talkapex.com/)
-- [Joel Kallman's Blog](https://joelkallman.blogspot.com/)
-- [Oracle APEX Website](https://apex.oracle.com/)
-
+- [7 days challenge](https://www.guru99.com/php-tutorials.html)
+- [The right way](https://phptherightway.com/)
+- [In site learn](https://www.learn-php.org/)
+- [Complete macos PHP setup](https://getgrav.org/blog/macos-mojave-apache-multiple-php-versions)
 
 ## Podcasts
 
@@ -228,6 +219,15 @@
 - [A Beginner's Guide to Service Workers](https://medium.com/samsung-internet-dev/a-beginners-guide-to-service-workers-f76abf1960f6)
 - [Progressive Web Application Codelab](https://codelabs.developers.google.com/codelabs/your-first-pwapp/#0)
 - [4 important points to know about Progressive Web Apps (PWA)](https://medium.com/@deepusnath/4-points-to-keep-in-mind-before-introducing-progressive-web-apps-pwa-to-your-team-8dc66bcf6011)
+
+## Python
+
+- [Learn Python the Hard Way](https://learnpythonthehardway.org/)
+- [CS50's Web Programming with Python and JavaScript](https://www.edx.org/course/cs50s-web-programming-with-python-and-javascript)
+- [Automate the Boring Stuff with Python](http://automatetheboringstuff.com/)
+- [Think Python 2nd Edition](http://greenteapress.com/wp/think-python-2e/)
+
+
 
 ## ReactJS
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 ## Table of Contents
 
 - [CSS](#css)
+- [Data Science](#data-science)
 - [Developer Blog](#developer-blog)
 - [Developer Stories](#developer-stories)
+- [Django](#django)
 - [Golang](#golang)
 - [GraphQL](#graphql)
 - [InfoSec](#infosec)
@@ -14,11 +16,13 @@
 - [Markdown](#markdown)
 - [Machine Learning](#machine-learning)
 - [PHP](#php)
+- [Python](#python)
 - [NodeJS](#nodejs)
 - [Oracle Application Express (APEX)](#APEX)
 - [Podcasts](#podcasts)
 - [PWA](#pwa)
 - [ReactJS](#reactjs)
+- [Ruby](#ruby)
 - [Serverless](#serverless)
 - [Sick Picks](#sick-picks)
 - [Typescript](#typescript)
@@ -43,6 +47,12 @@
 - [CSS Images](https://coding-artist.teachable.com/)
 - [Learn CSS Layouts](http://learnlayout.com/)
 
+## Date Science
+
+- [DataCamp](https://www.datacamp.com/)
+- [New Coder](http://newcoder.io/)
+- [Data Analysis in Python with Pandas](https://www.youtube.com/playlist?list=PL5-da3qGB5ICCsgW1MxlZ0Hq8LL5U3u9y)
+- [The Quartz Guide to Bad data](https://github.com/Quartz/bad-data-guide)
 
 ## Developer Blog
 
@@ -68,6 +78,10 @@
 - [My #100DaysofCode Experience — The Good, The Bad and The Ugly](https://code.likeagirl.io/my-100daysofcode-experience-the-good-the-bad-and-the-ugly-ee1263131f15)
 - [Advice From A 19 Year Old Girl & Software Developer](https://medium.com/@lydiahallie/advice-from-a-19-y-o-girl-software-developer-88737bcc6be5)
 - [Becoming an intermediate developer, keeping up with the Wars](https://hackernoon.com/becoming-intermediate-developer-keeping-up-with-the-wars-87bb518b40da)
+
+## Django
+- [Django Girls](https://tutorial.djangogirls.org/)
+- [Official Django Tutorials](https://docs.djangoproject.com/en/2.1/intro/tutorial01/)
 
 ## Golang
 
@@ -139,6 +153,13 @@
 - [Complete macos PHP setup](https://getgrav.org/blog/macos-mojave-apache-multiple-php-versions)
 
 
+## Python
+
+- [Learn Python the Hard Way](https://learnpythonthehardway.org/)
+- [CS50's Web Programming with Python and JavaScript](https://www.edx.org/course/cs50s-web-programming-with-python-and-javascript)
+- [Automate the Boring Stuff with Python](http://automatetheboringstuff.com/)
+- [Think Python 2nd Edition](http://greenteapress.com/wp/think-python-2e/)
+
 ## NodeJS
 
 - [Learn Node by Wes Bos](https://learnnode.com/)
@@ -161,7 +182,7 @@
 - [Node.js Production Checklist](https://goldbergyoni.com/checklist-best-practice-of-node-js-in-production/)
 - [Debugging Node.js Apps in Production](https://blog.risingstack.com/node-js-war-stories-solving-issues-in-production-2/)
 - [Node.js Performance Tips](https://www.smashingmagazine.com/2018/06/nodejs-tools-techniques-performance-servers/)
--[Measuring HTTP Timings with Node.js](https://blog.risingstack.com/measuring-http-timings-node-js/)
+- [Measuring HTTP Timings with Node.js](https://blog.risingstack.com/measuring-http-timings-node-js/)
 - [Advanced Node.js(videos)](https://onedrive.live.com/?authkey=%21ANbPcuk7XxY1hPY&id=9F66D67EBC33737F%2133343&cid=9F66D67EBC33737F)
 - [Node.js Interview Questions and Answers](https://blog.risingstack.com/node-js-interview-questions-and-answers-2017/)
 - [Tutorialspoint](https://www.tutorialspoint.com/nodejs/)
@@ -194,6 +215,12 @@
 - [ForLoop Pod](https://podcast.forloop.africa/)
 - [Soft Skills Engineering](https://softskills.audio/)
 - [Free Code Camp](https://freecodecamp.libsyn.com/)
+- [The Women in Tech Show](https://thewomenintechshow.com/)
+- [Front End Happy Hour](http://frontendhappyhour.com/)
+- [Pursuit Podcast](http://pursuit.tech/)
+- [Battle Tactics for Your Sexist Workplace](https://www.kuow.org/podcasts/battle-tactics/)
+- [Women in Tech](http://podcast.womenintechshow.com/episodes)
+
 
 ## PWA
 
@@ -207,6 +234,12 @@
 - [React for Beginners by Wes Bos](https://reactforbeginners.com/)
 - [Alligator.IO React Page](https://alligator.io/react/)
 - [Egghead.io](https://egghead.io/browse/frameworks/react)
+
+## Ruby
+
+- [Learn Ruby the Hard Way](https://learnrubythehardway.org/book/)
+- [The Ruby Reference](https://rubyreferences.github.io/rubyref/)
+- [Ada Developers Academy Jump Start](https://github.com/Ada-Developers-Academy/jump-start)
 
 ## Serverless
 
@@ -270,3 +303,4 @@
 - [Women Who Code](https://www.womenwhocode.com)
 - [Ladies of Code](https://www.ladiesofcode.com/)
 - [Women in Tech](https://www.womenintech.co.uk/)
+- [Tech Ladies](https://www.hiretechladies.com/)


### PR DESCRIPTION
I added sections and entries for python, ruby, django, and some general data science entries. Also added a few entries for podcasts and women in tech. It looks like the subjects towards the bottom of the list have become out of order. Let me know and I can get them in alphabetical order again.