### PR TITLE
Add Developer Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@
 - [Developer Roadmap](https://roadmap.sh)
 - [CodeWall](https://codewall.co.uk)
 - [Joshua Comeau](https://joshwcomeau.com/)
+- [Sara Soueidan](https://sarasoueidan.com/)
+- [Robin Weiruch](https://robinwieruch.de/)
+- [Wes Bos](https://wesbos.com/)
 
 ## Developer Stories
 


### PR DESCRIPTION
I have added some developer blogs to the list. 

- [Sara Soueidan](https://sarasoueidan.com/) - Web Design, CSS and Accessibility
- [Robin Weiruch](https://robinwieruch.de/) - React.js, Node.js AND GraphQL
- [Wes Bos](https://wesbos.com/) - Javascript, React.js, Node.js, Gatsby and Next.js
